### PR TITLE
Исправить отправку текста

### DIFF
--- a/src/main/kotlin/com/curlylab/curlylabApiGateway/ApiGatewayController.kt
+++ b/src/main/kotlin/com/curlylab/curlylabApiGateway/ApiGatewayController.kt
@@ -304,10 +304,6 @@ class ApiGatewayController (
         return Mono.defer {
            val hasFile = file != null
            var hasText = text != null
-            println(file)
-            println(hasFile)
-            println(text)
-            println(hasText)
 
             when {
                 (hasFile && hasText) || !(hasFile || hasText) -> {


### PR DESCRIPTION
Невозможно одновременно картинку на анализ, так как отправка пустого поля считается непустым текстом. Необходимо исправить приём пустого поля от клиента с обработкой случая, когда отправляется только картинка.